### PR TITLE
Respect `charset` in Content-Type:

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "aws-sdk": "^2.2.22",
+    "content-type": "^1.0.2",
     "mailparser": "^0.5.3",
     "node-uuid": "^1.4.7"
   },


### PR DESCRIPTION
In some regions, people send/receive mails non UTF-8 encoded.
This patch is not helps them completely. But they will get the better experience.
